### PR TITLE
Edited main to fix compilation errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -110,16 +110,16 @@ const BACKGROUND_COLOUR: [f32; 4] = [0.25, 0.25, 0.25, 0.0]; // dark grey
 pub fn run() -> Result<(), amethyst::Error> {
     let _ = &config::GAME_CONFIGURATION; // initialises game constants
 
-    let application_root = application_root_dir()?;
+    let application_root = application_root_dir();
 
     // Set the display configuration path to <package root>/resources/display_config.ron.
-    let display_config_path =  application_root.join("resources/display_config.ron");
+    let display_config_path = format!("{}/resources/display_config.ron", application_root);
     let display_config = DisplayConfig::load(&display_config_path);
 
     // Load up the key bindings path and the resources path
-    let key_bindings_path = application_root.join("resources/input.ron");
+    let key_bindings_path = format!("{}/resources/input.ron", application_root);
 
-    let resources_path = application_root.join("assets");
+    let resources_path = format!("{}/assets", application_root);
 
     // Create a pipeline that has three passes:
     // 1. setting the background to the background colour constant


### PR DESCRIPTION
I got multiple compilation errors in this file on linux, which seems strange? It's also following the Amethyst style of using format for the paths now.

![deepinscreenshot_select-area_20190112205807](https://user-images.githubusercontent.com/3596182/51077904-01fcaa80-16ad-11e9-85d0-17e69d040649.png)
Followed by
![deepinscreenshot_select-area_20190112205831](https://user-images.githubusercontent.com/3596182/51077903-01fcaa80-16ad-11e9-9854-49419bd0c140.png)

