### PR TITLE
Fixed filepath using correct capitalization

### DIFF
--- a/src/entities/laser.rs
+++ b/src/entities/laser.rs
@@ -25,7 +25,7 @@ use crate::resources::LaserResource;
 /// that will be attached to the entity when we create it in
 /// [fire_laser](fn.fire_laser.html).
 pub fn initialise_laser_resource(world: &mut World) -> LaserResource {
-    let (mesh, material) = png_mesh_and_material("PNG/Lasers/LaserRed01.png", [9.0,54.0], world);
+    let (mesh, material) = png_mesh_and_material("PNG/Lasers/laserRed01.png", [9.0,54.0], world);
     let laser_resource = LaserResource {
         mesh,
         material,


### PR DESCRIPTION
While in Windows capitalization in file names doesn't matter, on linux it doesn't correctly find the PNG due to the lower l instead of capital L in the real image name.

Love the project, huge help as a reference :)!